### PR TITLE
Fixed Negative Class statistics and added test cases

### DIFF
--- a/psl-evaluation/src/main/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionComparator.java
+++ b/psl-evaluation/src/main/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionComparator.java
@@ -78,7 +78,7 @@ public class DiscretePredictionComparator implements PredictionComparator {
 	@Override
 	public DiscretePredictionStatistics compare(Predicate p) {
 		countResultDBStats(p);
-		//System.out.println("tp " + tp + " fp " + fp + " tn " + tn + " fn " + fn);
+        //System.out.println("TEST:\ntp " + tp + " fp " + fp + " tn " + tn + " fn " + fn);
 		return new DiscretePredictionStatistics(tp, fp, tn, fn, threshold, errors, correctAtoms);
 	}
 	
@@ -110,6 +110,7 @@ public class DiscretePredictionComparator implements PredictionComparator {
 		}
 		
 		tn = maxBaseAtoms - tp - fp - fn;
+        //System.out.println("TEST:\ntp " + tp + " fp " + fp + " tn " + tn + " fn " + fn);
 		return new DiscretePredictionStatistics(tp, fp, tn, fn, threshold, errors, correctAtoms);
 	}
 	
@@ -143,7 +144,7 @@ public class DiscretePredictionComparator implements PredictionComparator {
 			if (baselineAtom instanceof ObservedAtom) {
 				actual = (resultAtom.getValue() >= threshold);
 				expected = (baselineAtom.getValue() >= threshold);
-				if (actual && expected || !actual && !expected) {
+				if ((actual && expected) || (!actual && !expected)) {
 					// True negative
 					if (!actual)
 						tn++;

--- a/psl-evaluation/src/main/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionComparator.java
+++ b/psl-evaluation/src/main/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionComparator.java
@@ -78,7 +78,6 @@ public class DiscretePredictionComparator implements PredictionComparator {
 	@Override
 	public DiscretePredictionStatistics compare(Predicate p) {
 		countResultDBStats(p);
-        //System.out.println("TEST:\ntp " + tp + " fp " + fp + " tn " + tn + " fn " + fn);
 		return new DiscretePredictionStatistics(tp, fp, tn, fn, threshold, errors, correctAtoms);
 	}
 	
@@ -110,7 +109,6 @@ public class DiscretePredictionComparator implements PredictionComparator {
 		}
 		
 		tn = maxBaseAtoms - tp - fp - fn;
-        //System.out.println("TEST:\ntp " + tp + " fp " + fp + " tn " + tn + " fn " + fn);
 		return new DiscretePredictionStatistics(tp, fp, tn, fn, threshold, errors, correctAtoms);
 	}
 	
@@ -137,32 +135,36 @@ public class DiscretePredictionComparator implements PredictionComparator {
 		while (iter.hasNext()) {
 			resultAtom = iter.next();
 			args = new Constant[resultAtom.getArity()];
-			for (int i = 0; i < args.length; i++)
+			for (int i = 0; i < args.length; i++) {
 				args[i] = (Constant) resultAtom.getArguments()[i];
+			}
 			baselineAtom = baseline.getAtom(resultAtom.getPredicate(), args);
 			
-			if (baselineAtom instanceof ObservedAtom) {
-				actual = (resultAtom.getValue() >= threshold);
-				expected = (baselineAtom.getValue() >= threshold);
-				if ((actual && expected) || (!actual && !expected)) {
-					// True negative
-					if (!actual)
-						tn++;
-					// True positive
-					else
-						tp++;
-					correctAtoms.add(resultAtom);
+			if (!(baselineAtom instanceof ObservedAtom)) {
+				continue;
+			}
+			actual = (resultAtom.getValue() >= threshold);
+			expected = (baselineAtom.getValue() >= threshold);
+			if ((actual && expected) || (!actual && !expected)) {
+				// True negative
+				if (!actual) {
+					tn++;
 				}
-				// False negative
-				else if (!actual) {
-					fn++;
-					errors.put(resultAtom, -1.0);
-				}
-				// False positive
+				// True positive
 				else {
-					fp++;
-					errors.put(resultAtom, 1.0);
+					tp++;
 				}
+				correctAtoms.add(resultAtom);
+			}
+			// False negative
+			else if (!actual) {
+				fn++;
+				errors.put(resultAtom, -1.0);
+			}
+			// False positive
+			else {
+				fp++;
+				errors.put(resultAtom, 1.0);
 			}
 		}
 	}

--- a/psl-evaluation/src/main/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionStatistics.java
+++ b/psl-evaluation/src/main/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionStatistics.java
@@ -47,7 +47,7 @@ public class DiscretePredictionStatistics implements PredictionStatistics {
 	private final Set<GroundAtom> correctAtoms;
 	
 	public DiscretePredictionStatistics(int tp, int fp, int tn, int fn,
-		double threshold, Map<GroundAtom, Double> errors, Set<GroundAtom> correctAtoms) {
+			double threshold, Map<GroundAtom, Double> errors, Set<GroundAtom> correctAtoms) {
 		this.tp = tp;
 		this.fp = fp;
 		this.tn = tn;
@@ -138,7 +138,7 @@ public class DiscretePredictionStatistics implements PredictionStatistics {
 		if (sum == 0.0) { 
 			return 0.0;
 		}
-		return 2*(prec*rec)/sum;
+		return 2 * (prec * rec) / sum;
 	}
 	
 	public double getAccuracy() {

--- a/psl-evaluation/src/main/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionStatistics.java
+++ b/psl-evaluation/src/main/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionStatistics.java
@@ -115,13 +115,13 @@ public class DiscretePredictionStatistics implements PredictionStatistics {
 			double n = tn + fp;
 			if (n == 0.0)
 				return 1.0;
-			return tn/(tn+fp);
+			return tn/n;
 		}
 		else {
 			double p = tp + fn;
 			if (p == 0.0)
 				return 1.0;
-			return tp/(p);
+			return tp/p;
 		}
 	}
 	

--- a/psl-evaluation/src/main/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionStatistics.java
+++ b/psl-evaluation/src/main/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionStatistics.java
@@ -47,7 +47,7 @@ public class DiscretePredictionStatistics implements PredictionStatistics {
 	private final Set<GroundAtom> correctAtoms;
 	
 	public DiscretePredictionStatistics(int tp, int fp, int tn, int fn,
-			double threshold, Map<GroundAtom, Double> errors, Set<GroundAtom> correctAtoms) {
+		double threshold, Map<GroundAtom, Double> errors, Set<GroundAtom> correctAtoms) {
 		this.tp = tp;
 		this.fp = fp;
 		this.tn = tn;
@@ -87,10 +87,12 @@ public class DiscretePredictionStatistics implements PredictionStatistics {
 
 			@Override
 			public boolean apply(Entry<GroundAtom, Double> e) {
-				if (e.getValue() < 0.0)
+				if (e.getValue() < 0.0) {
 					return true;
-				else
+				}
+				else {
 					return false;
+				}
 			}
 		});
 	}
@@ -98,47 +100,53 @@ public class DiscretePredictionStatistics implements PredictionStatistics {
 	public double getPrecision(BinaryClass c) {
 		if (c == BinaryClass.NEGATIVE) {
 			double n = tn + fn;
-			if (n == 0.0)
+			if (n == 0.0) {
 				return 1.0;
-			return tn/n;
+			}
+			return tn / n;
 		}
 		else {
 			double p = tp + fp;
-			if (p == 0.0)
+			if (p == 0.0) {
 				return 1.0;
-			return tp/p;
+			}
+			return tp / p;
 		}
 	}
 	
 	public double getRecall(BinaryClass c) {
 		if (c == BinaryClass.NEGATIVE) {
 			double n = tn + fp;
-			if (n == 0.0)
+			if (n == 0.0) {
 				return 1.0;
-			return tn/n;
+			}
+			return tn / n;
 		}
 		else {
 			double p = tp + fn;
-			if (p == 0.0)
+			if (p == 0.0) {
 				return 1.0;
-			return tp/p;
+			}
+			return tp / p;
 		}
 	}
 	
 	public double getF1(BinaryClass c) {
-		double prec = this.getPrecision(c);
-		double rec = this.getRecall(c);
+		double prec = getPrecision(c);
+		double rec = getRecall(c);
 		double sum = prec + rec;
-		if (sum == 0.0)
+		if (sum == 0.0) { 
 			return 0.0;
+		}
 		return 2*(prec*rec)/sum;
 	}
 	
 	public double getAccuracy() {
-		int numAtoms = getNumAtoms();
-		if (numAtoms == 0)
-			return 0;
-		return (tp + tn) / (double)getNumAtoms();
+		double numAtoms = getNumAtoms();
+		if (numAtoms == 0.0) {
+			return 0.0;
+		}
+		return (tp + tn) / numAtoms;
 	}
 
 	@Override

--- a/psl-evaluation/src/test/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionComparatorTest.java
+++ b/psl-evaluation/src/test/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionComparatorTest.java
@@ -136,7 +136,7 @@ public class DiscretePredictionComparatorTest {
 			DiscretePredictionStatistics comparison = comparator.compare(predicate, MAX_BASE_ATOMS);
 			double f1 = comparison.getF1(DiscretePredictionStatistics.BinaryClass.POSITIVE);
 			if (threshold <= 0.8) {
-				assertEquals(2.0/3.0, f1, 1e-5);
+				assertEquals(2.0 / 3.0, f1, 1e-5);
 			}
 			else {
 				assertEquals(0.0, f1, 1e-5);
@@ -154,7 +154,7 @@ public class DiscretePredictionComparatorTest {
 				assertEquals(0.9, acc, 1e-5);
 			}
 			else {
-				assertEquals(26.0/30.0, acc, 1e-5);
+				assertEquals(26.0 / 30.0, acc, 1e-5);
 			}
 		}
 	}
@@ -166,10 +166,10 @@ public class DiscretePredictionComparatorTest {
 			DiscretePredictionStatistics comparison = comparator.compare(predicate, MAX_BASE_ATOMS);
 			double prec = comparison.getPrecision(DiscretePredictionStatistics.BinaryClass.NEGATIVE);
 			if (threshold <= 0.8) {
-				assertEquals(24.0/25.0, prec, 1e-5);
+				assertEquals(24.0 / 25.0, prec, 1e-5);
 			}
 			else {
-				assertEquals(26.0/30.0, prec, 1e-5);
+				assertEquals(26.0 / 30.0, prec, 1e-5);
 			}
 		}
 	}
@@ -181,12 +181,12 @@ public class DiscretePredictionComparatorTest {
 			DiscretePredictionStatistics comparison = comparator.compare(predicate, MAX_BASE_ATOMS);
 			double recall = comparison.getRecall(DiscretePredictionStatistics.BinaryClass.NEGATIVE);
 			if (threshold <= 0.8) {
-				assertEquals(24.0/26.0, recall, 1e-5);
+				assertEquals(24.0 / 26.0, recall, 1e-5);
 			}
 			else {
 				assertEquals(1.0, recall, 1e-5);
 			}
-		}		
+		}
 	}
 	
 	@Test
@@ -196,12 +196,12 @@ public class DiscretePredictionComparatorTest {
 			DiscretePredictionStatistics comparison = comparator.compare(predicate, MAX_BASE_ATOMS);
 			double f1 = comparison.getF1(DiscretePredictionStatistics.BinaryClass.NEGATIVE);
 			if (threshold <= 0.8) {
-				assertEquals(16.0/17.0, f1, 1e-5);
+				assertEquals(16.0 / 17.0, f1, 1e-5);
 			}
 			else {
-				assertEquals(13.0/14.0, f1, 1e-5);
+				assertEquals(13.0 / 14.0, f1, 1e-5);
 			}
-		}		
+		}
 	}
 	
 }

--- a/psl-evaluation/src/test/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionComparatorTest.java
+++ b/psl-evaluation/src/test/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionComparatorTest.java
@@ -60,6 +60,9 @@ public class DiscretePredictionComparatorTest {
 		Database baseline = ds.getDatabase(ds.getPartition("2"), ds.getPartition("2"));
 		
 		// create some canned ground inference atoms
+		// The size 5 corresponds to NUM_GROUND_INF_ATOMS
+		// The number 6 of unique keys passed in ds.getUniqueID (1,2,3,4,5,6) 
+		//    corresponds to NUM_UNIQ_CONSTANTS
 		Constant[][] cannedTerms = new Constant[5][];
 		cannedTerms[0] = new Constant[]{ ds.getUniqueID(1), ds.getUniqueID(2) };
 		cannedTerms[1] = new Constant[]{ ds.getUniqueID(2), ds.getUniqueID(1) };

--- a/psl-evaluation/src/test/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionComparatorTest.java
+++ b/psl-evaluation/src/test/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionComparatorTest.java
@@ -40,6 +40,9 @@ public class DiscretePredictionComparatorTest {
 
 	private StandardPredicate predicate;
 	private DiscretePredictionComparator comparator;
+	private static final int NUM_GROUND_INF_ATOMS = 5;
+	private static final int NUM_UNIQ_CONSTANTS = 6;
+	private static final int MAX_BASE_ATOMS = NUM_GROUND_INF_ATOMS * NUM_UNIQ_CONSTANTS;
 	
 	@Before
 	public void setUp() throws Exception {
@@ -95,92 +98,106 @@ public class DiscretePredictionComparatorTest {
 
 	@Test
 	public void testPrecision() {
-		for (double thresh = 0.1; thresh <= 1.0; thresh += 0.1) {
-			comparator.setThreshold(thresh);
-			DiscretePredictionStatistics comparison = comparator.compare(predicate, 6*5);
+		for (double threshold = 0.1; threshold <= 1.0; threshold += 0.1) {
+			comparator.setThreshold(threshold);
+			DiscretePredictionStatistics comparison = comparator.compare(predicate, MAX_BASE_ATOMS);
 			double prec = comparison.getPrecision(DiscretePredictionStatistics.BinaryClass.POSITIVE);
-			if (thresh <= 0.8)
-				assertEquals(0.6, prec, 1e-10);
-			else
-				assertEquals(1.0, prec, 1e-10);
+			if (threshold <= 0.8) {
+				assertEquals(0.6, prec, 1e-5);
+			}
+			else {
+				assertEquals(1.0, prec, 1e-5);
+			}
 		}
 	}
 	
 	@Test
 	public void testRecall() {
-		for (double thresh = 0.1; thresh <= 1.0; thresh += 0.1) {
-			comparator.setThreshold(thresh);
-			DiscretePredictionStatistics comparison = comparator.compare(predicate, 6*5);
+		for (double threshold = 0.1; threshold <= 1.0; threshold += 0.1) {
+			comparator.setThreshold(threshold);
+			DiscretePredictionStatistics comparison = comparator.compare(predicate, MAX_BASE_ATOMS);
 			double recall = comparison.getRecall(DiscretePredictionStatistics.BinaryClass.POSITIVE);
-			if (thresh <= 0.8)
-				assertEquals(0.75, recall, 1e-10);
-			else
-				assertEquals(0.0, recall, 1e-10);
-		}		
+			if (threshold <= 0.8) {
+				assertEquals(0.75, recall, 1e-5);
+			}
+			else {
+				assertEquals(0.0, recall, 1e-5);
+			}
+		}
 	}
 	
 	@Test
 	public void testF1() {
-		for (double thresh = 0.1; thresh <= 1.0; thresh += 0.1) {
-			comparator.setThreshold(thresh);
-			DiscretePredictionStatistics comparison = comparator.compare(predicate, 6*5);
+		for (double threshold = 0.1; threshold <= 1.0; threshold += 0.1) {
+			comparator.setThreshold(threshold);
+			DiscretePredictionStatistics comparison = comparator.compare(predicate, MAX_BASE_ATOMS);
 			double f1 = comparison.getF1(DiscretePredictionStatistics.BinaryClass.POSITIVE);
-			if (thresh <= 0.8)
-				assertEquals(2.0/3.0, f1, 1e-10);
-			else
-				assertEquals(0.0, f1, 1e-10);
-		}		
+			if (threshold <= 0.8) {
+				assertEquals(2.0/3.0, f1, 1e-5);
+			}
+			else {
+				assertEquals(0.0, f1, 1e-5);
+			}
+		}
 	}
 	
 	@Test
 	public void testAccuracy() {
-		for (double thresh = 0.1; thresh <= 1.0; thresh += 0.1) {
-			comparator.setThreshold(thresh);
-			DiscretePredictionStatistics comparison = comparator.compare(predicate, 6*5);
+		for (double threshold = 0.1; threshold <= 1.0; threshold += 0.1) {
+			comparator.setThreshold(threshold);
+			DiscretePredictionStatistics comparison = comparator.compare(predicate, MAX_BASE_ATOMS);
 			double acc = comparison.getAccuracy();
-			if (thresh <= 0.8)
-				assertEquals(0.9, acc, 1e-10);
-			else
-				assertEquals(26.0/30.0, acc, 1e-10);
-		}		
+			if (threshold <= 0.8) {
+				assertEquals(0.9, acc, 1e-5);
+			}
+			else {
+				assertEquals(26.0/30.0, acc, 1e-5);
+			}
+		}
 	}
 
 	@Test
 	public void testPrecisionNegativeClass() {
-		for (double thresh = 0.1; thresh <= 1.0; thresh += 0.1) {
-			comparator.setThreshold(thresh);
-			DiscretePredictionStatistics comparison = comparator.compare(predicate, 6*5);
+		for (double threshold = 0.1; threshold <= 1.0; threshold += 0.1) {
+			comparator.setThreshold(threshold);
+			DiscretePredictionStatistics comparison = comparator.compare(predicate, MAX_BASE_ATOMS);
 			double prec = comparison.getPrecision(DiscretePredictionStatistics.BinaryClass.NEGATIVE);
-			if (thresh <= 0.8)
-				assertEquals(24.0/25.0, prec, 1e-10);
-			else
-				assertEquals(26.0/30.0, prec, 1e-10);
+			if (threshold <= 0.8) {
+				assertEquals(24.0/25.0, prec, 1e-5);
+			}
+			else {
+				assertEquals(26.0/30.0, prec, 1e-5);
+			}
 		}
 	}
 	
 	@Test
 	public void testRecallNegativeClass() {
-		for (double thresh = 0.1; thresh <= 1.0; thresh += 0.1) {
-			comparator.setThreshold(thresh);
-			DiscretePredictionStatistics comparison = comparator.compare(predicate, 6*5);
+		for (double threshold = 0.1; threshold <= 1.0; threshold += 0.1) {
+			comparator.setThreshold(threshold);
+			DiscretePredictionStatistics comparison = comparator.compare(predicate, MAX_BASE_ATOMS);
 			double recall = comparison.getRecall(DiscretePredictionStatistics.BinaryClass.NEGATIVE);
-			if (thresh <= 0.8)
-				assertEquals(24.0/26.0, recall, 1e-10);
-			else
-				assertEquals(1.0, recall, 1e-10);
+			if (threshold <= 0.8) {
+				assertEquals(24.0/26.0, recall, 1e-5);
+			}
+			else {
+				assertEquals(1.0, recall, 1e-5);
+			}
 		}		
 	}
 	
 	@Test
 	public void testF1NegativeClass() {
-		for (double thresh = 0.1; thresh <= 1.0; thresh += 0.1) {
-			comparator.setThreshold(thresh);
-			DiscretePredictionStatistics comparison = comparator.compare(predicate, 6*5);
+		for (double threshold = 0.1; threshold <= 1.0; threshold += 0.1) {
+			comparator.setThreshold(threshold);
+			DiscretePredictionStatistics comparison = comparator.compare(predicate, MAX_BASE_ATOMS);
 			double f1 = comparison.getF1(DiscretePredictionStatistics.BinaryClass.NEGATIVE);
-			if (thresh <= 0.8)
-				assertEquals(16.0/17.0, f1, 1e-10);
-			else
-				assertEquals(13.0/14.0, f1, 1e-10);
+			if (threshold <= 0.8) {
+				assertEquals(16.0/17.0, f1, 1e-5);
+			}
+			else {
+				assertEquals(13.0/14.0, f1, 1e-5);
+			}
 		}		
 	}
 	

--- a/psl-evaluation/src/test/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionComparatorTest.java
+++ b/psl-evaluation/src/test/java/org/linqs/psl/utils/evaluation/statistics/DiscretePredictionComparatorTest.java
@@ -144,4 +144,44 @@ public class DiscretePredictionComparatorTest {
 				assertEquals(26.0/30.0, acc, 1e-10);
 		}		
 	}
+
+	@Test
+	public void testPrecisionNegativeClass() {
+		for (double thresh = 0.1; thresh <= 1.0; thresh += 0.1) {
+			comparator.setThreshold(thresh);
+			DiscretePredictionStatistics comparison = comparator.compare(predicate, 6*5);
+			double prec = comparison.getPrecision(DiscretePredictionStatistics.BinaryClass.NEGATIVE);
+			if (thresh <= 0.8)
+				assertEquals(24.0/25.0, prec, 1e-10);
+			else
+				assertEquals(26.0/30.0, prec, 1e-10);
+		}
+	}
+	
+	@Test
+	public void testRecallNegativeClass() {
+		for (double thresh = 0.1; thresh <= 1.0; thresh += 0.1) {
+			comparator.setThreshold(thresh);
+			DiscretePredictionStatistics comparison = comparator.compare(predicate, 6*5);
+			double recall = comparison.getRecall(DiscretePredictionStatistics.BinaryClass.NEGATIVE);
+			if (thresh <= 0.8)
+				assertEquals(24.0/26.0, recall, 1e-10);
+			else
+				assertEquals(1.0, recall, 1e-10);
+		}		
+	}
+	
+	@Test
+	public void testF1NegativeClass() {
+		for (double thresh = 0.1; thresh <= 1.0; thresh += 0.1) {
+			comparator.setThreshold(thresh);
+			DiscretePredictionStatistics comparison = comparator.compare(predicate, 6*5);
+			double f1 = comparison.getF1(DiscretePredictionStatistics.BinaryClass.NEGATIVE);
+			if (thresh <= 0.8)
+				assertEquals(16.0/17.0, f1, 1e-10);
+			else
+				assertEquals(13.0/14.0, f1, 1e-10);
+		}		
+	}
+	
 }


### PR DESCRIPTION
There was an int to double (non) conversion issue with the calculation of recall for the negative class in DiscretePredicationStatistics. Fixed that and added test cases for negative class P,R,F1.